### PR TITLE
add build variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: build (${{ matrix.job_name }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -15,20 +16,16 @@ jobs:
           - mcu: STM32G431
             variant_flag: ""
             job_name: STM32G431
-            artifact_suffix: ""
           - mcu: STM32G431
             variant_flag: "-DBUILD_VARIANT=VTX"
             job_name: STM32G431_VTX
-            artifact_suffix: "_VTX"
 
           - mcu: STM32G474
             variant_flag: ""
             job_name: STM32G474
-            artifact_suffix: ""
           - mcu: STM32G474
             variant_flag: "-DBUILD_VARIANT=VTX"
             job_name: STM32G474_VTX
-            artifact_suffix: "_VTX"
 
     steps:
     - name: Checkout
@@ -54,11 +51,11 @@ jobs:
     - name : Upload HEX
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.job_name }}_HEX"
+        name: "OpenPixelOSD_${{ matrix.job_name }}_HEX"
         path: ${{ github.workspace }}/build-${{ matrix.job_name }}/*.hex
 
     - name: Upload BIN
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.job_name }}_BIN"
+        name: "OpenPixelOSD_${{ matrix.job_name }}_BIN"
         path: ${{ github.workspace }}/build-${{ matrix.job_name }}/*.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,25 +12,23 @@ jobs:
     strategy:
       matrix:
         include:
-          # ---- STM32G431 ----
           - mcu: STM32G431
-            variant_name: default
             variant_flag: ""
-            variant_suffix: ""
+            job_name: STM32G431
+            artifact_suffix: ""
           - mcu: STM32G431
-            variant_name: VTX
             variant_flag: "-DBUILD_VARIANT=VTX"
-            variant_suffix: "_VTX"
+            job_name: STM32G431_VTX
+            artifact_suffix: "_VTX"
 
-          # ---- STM32G474 ----
           - mcu: STM32G474
-            variant_name: default
             variant_flag: ""
-            variant_suffix: ""
+            job_name: STM32G474
+            artifact_suffix: ""
           - mcu: STM32G474
-            variant_name: VTX
             variant_flag: "-DBUILD_VARIANT=VTX"
-            variant_suffix: "_VTX"
+            job_name: STM32G474_VTX
+            artifact_suffix: "_VTX"
 
     steps:
     - name: Checkout
@@ -45,10 +43,10 @@ jobs:
         release: '14.2.Rel1' # <-- The compiler release to use
 
     - name : Create build directory
-      run: mkdir -p build-${{ matrix.mcu }}-${{ matrix.variant_name }}
+      run: mkdir -p build-${{ matrix.job_name }}
 
     - name : Configure & Build
-      working-directory: ./build-${{ matrix.mcu }}-${{ matrix.variant_name }}
+      working-directory: ./build-${{ matrix.job_name }}
       run: |
         cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTARGET_MCU=${{ matrix.mcu }} ${{ matrix.variant_flag }} ..
         make -j"$(nproc)"
@@ -56,11 +54,11 @@ jobs:
     - name : Upload HEX
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.mcu }}${{ matrix.variant_suffix }}_HEX"
-        path: ${{ github.workspace }}/build-${{ matrix.mcu }}-${{ matrix.variant_name }}/*.hex
+        name: "firmware_${{ matrix.job_name }}_HEX"
+        path: ${{ github.workspace }}/build-${{ matrix.job_name }}/*.hex
 
     - name: Upload BIN
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.mcu }}${{ matrix.variant_suffix }}_BIN"
-        path: ${{ github.workspace }}/build-${{ matrix.mcu }}-${{ matrix.variant_name }}/*.bin
+        name: "firmware_${{ matrix.job_name }}_BIN"
+        path: ${{ github.workspace }}/build-${{ matrix.job_name }}/*.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,34 @@ name: build-ubuntu
 env:
   BUILD_TYPE: Release
 
-# Triggers the workflow on push or pull request events
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        mcu: [ G431, G474 ]
+        include:
+          # ---- STM32G431 ----
+          - mcu: STM32G431
+            variant_name: default
+            variant_flag: ""
+            variant_suffix: ""
+          - mcu: STM32G431
+            variant_name: VTX
+            variant_flag: "-DBUILD_VARIANT=VTX"
+            variant_suffix: "_VTX"
+
+          # ---- STM32G474 ----
+          - mcu: STM32G474
+            variant_name: default
+            variant_flag: ""
+            variant_suffix: ""
+          - mcu: STM32G474
+            variant_name: VTX
+            variant_flag: "-DBUILD_VARIANT=VTX"
+            variant_suffix: "_VTX"
 
     steps:
     - name: Checkout
@@ -28,22 +45,22 @@ jobs:
         release: '14.2.Rel1' # <-- The compiler release to use
 
     - name : Create build directory
-      run: mkdir -p build-${{ matrix.mcu }}
+      run: mkdir -p build-${{ matrix.mcu }}-${{ matrix.variant_name }}
 
-    - name: build
-      working-directory: ./build-${{ matrix.mcu }}
+    - name : Configure & Build
+      working-directory: ./build-${{ matrix.mcu }}-${{ matrix.variant_name }}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTARGET_MCU=${{ matrix.mcu }} ..
-        make -j4
+        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTARGET_MCU=${{ matrix.mcu }} ${{ matrix.variant_flag }} ..
+        make -j"$(nproc)"
 
-    - name: Upload Artifacts HEX
+    - name : Upload HEX
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.mcu }}_HEX"
-        path: ${{runner.workspace}}/OpenPixelOSD/build-${{ matrix.mcu }}/*.hex
+        name: "firmware_${{ matrix.mcu }}${{ matrix.variant_suffix }}_HEX"
+        path: ${{ github.workspace }}/build-${{ matrix.mcu }}-${{ matrix.variant_name }}/*.hex
 
-    - name: Upload Artifacts BIN
+    - name: Upload BIN
       uses: actions/upload-artifact@v4
       with:
-        name: "firmware_${{ matrix.mcu }}_BIN"
-        path: ${{runner.workspace}}/OpenPixelOSD/build-${{ matrix.mcu }}/*.bin
+        name: "firmware_${{ matrix.mcu }}${{ matrix.variant_suffix }}_BIN"
+        path: ${{ github.workspace }}/build-${{ matrix.mcu }}-${{ matrix.variant_name }}/*.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
 cmake_minimum_required(VERSION 3.22)
+# ===== Build variant selection =====
+#   OpenPixelOSD      -> base OSD (no VTX drivers)
+#   OpenPixelOSD_VTX  -> OSD + VTX (RTC6705 / PA / MSP VTX)
+set(BUILD_VARIANT "" CACHE STRING "Build variant: VTX")
 
-set(TARGET_MCU "" CACHE STRING "Target MCU (e.g., G431, G474)")
+set(TARGET_MCU "" CACHE STRING "Target MCU (e.g., STM32G431, STM32G474)")
 # set default to G431 if not specified
 if(NOT TARGET_MCU)
-    set(TARGET_MCU G431)
+    set(TARGET_MCU STM32G431)
 endif()
 
-message(STATUS "Selected TARGET_MCU=${TARGET_MCU}")
+message(STATUS "Selected TARGET_MCU=${TARGET_MCU} BUILD_VARIANT=${BUILD_VARIANT}")
 
 if(UNIX AND NOT APPLE)
     # Linux
@@ -90,7 +94,7 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 add_executable(${CMAKE_PROJECT_NAME})
 
 
-if(TARGET_MCU STREQUAL "G431")
+if(TARGET_MCU STREQUAL "STM32G431")
     message(STATUS "Building for STM32G431")
     add_compile_definitions(
             MCU_TYPE=\"STM32G431\"
@@ -99,7 +103,7 @@ if(TARGET_MCU STREQUAL "G431")
     )
     set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/stm32g431cbux_flash.ld)
     set(STARTUP_ASSEMBLY_FILE ./src/stm32g4xx/startup_stm32g431xx.s)
-elseif(TARGET_MCU STREQUAL "G474")
+elseif(TARGET_MCU STREQUAL "STM32G474")
     message(STATUS "Building for STM32G474")
     add_compile_definitions(
             MCU_TYPE=\"STM32G474\"
@@ -111,6 +115,16 @@ elseif(TARGET_MCU STREQUAL "G474")
     set(SOURCE src/fonts/font_system.c)
 else()
     message(FATAL_ERROR "Unsupported MCU type: ${TARGET_MCU}")
+endif()
+
+if(BUILD_VARIANT STREQUAL "VTX")
+    message(STATUS "Building with VTX support")
+    set(BUILD_NAME "_VTX")
+    add_compile_definitions(BUILD_VARIANT_VTX)
+    set(VTX_SRC
+            ./src/rtc6705.c
+            ./src/rf_pa.c
+            ./src/vtx_msp.c)
 endif()
 
 add_compile_definitions(
@@ -129,6 +143,7 @@ target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         ${STARTUP_ASSEMBLY_FILE}
         ${SOURCE}
+        ${VTX_SRC}
         ./src/stm32g4xx/stm32g4xx_it.c
         ./src/stm32g4xx/system_stm32g4xx.c
         ./src/stm32g4xx/sysmem.c
@@ -150,9 +165,6 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         ./src/msp_displayport.c
         ./src/fonts/update_font.c
         ./src/video_graphics.c
-        ./src/rtc6705.c
-        ./src/rf_pa.c
-        ./src/vtx_msp.c
         ./src/main.c
 
 )
@@ -177,8 +189,8 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
 
 
 # Generate hex and bin files
-set(HEX_FILE ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${TARGET_MCU}.hex)
-set(BIN_FILE ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${TARGET_MCU}.bin)
+set(HEX_FILE ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${TARGET_MCU}${BUILD_NAME}.hex)
+set(BIN_FILE ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${TARGET_MCU}${BUILD_NAME}.bin)
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}> ${HEX_FILE}

--- a/src/main.c
+++ b/src/main.c
@@ -8,10 +8,10 @@
 #include "usb.h"
 #include "video_gen.h"
 #include "video_overlay.h"
-
+#if defined(BUILD_VARIANT_VTX)
 #include "rtc6705.h"
-
 #include <rf_pa.h>
+#endif
 #include <stdio.h>
 
 #if defined(HIGH_RAM)
@@ -52,6 +52,7 @@ int main (void)
 #endif
     msp_displayport_init();
 
+#if defined(BUILD_VARIANT_VTX)
     if(rtc6705_init()) {
         printf("rtc6705 detected\r\n");
         rtc6705_set_frequency(5880); // TODO: remove after implementing configuration saving to flash
@@ -59,6 +60,7 @@ int main (void)
         rf_pa_init();
         rf_pa_set_power_level(RF_PA_PWR_20mW);
     }
+#endif
 
     while (1)
     {

--- a/src/video_graphics.c
+++ b/src/video_graphics.c
@@ -413,5 +413,7 @@ void video_draw_3d_cube_animation(void)
     if (angle_y >= 2 * M_PI) angle_y -= 2 * M_PI;
     if (angle_z >= 2 * M_PI) angle_z -= 2 * M_PI;
 }
-
+#else
+// Empty file placeholder
+void empty_unit(void) {}
 #endif


### PR DESCRIPTION
This PR extends the build system to support multiple build variants of OpenPixelOSD:
When BUILD_VARIANT=VTX, additional VTX sources (rtc6705.c, rf_pa.c, vtx_msp.c) are included.

- Default (base OSD) build for STM32G431 and STM32G474
- VTX-enabled build (-DBUILD_VARIANT=VTX) for STM32G431 and STM32G474

Example usage cmake
```bash
# ===== Build default OSD (no VTX) =====

# STM32G431
cmake -B build-g431 -S . -DCMAKE_BUILD_TYPE=Release -DTARGET_MCU=STM32G431
cmake --build build-g431

# STM32G474
cmake -B build-g474 -S . -DCMAKE_BUILD_TYPE=Release -DTARGET_MCU=STM32G474
cmake --build build-g474


# ===== Build OSD with VTX support =====

# STM32G431 + VTX
cmake -B build-g431-vtx -S . -DCMAKE_BUILD_TYPE=Release -DTARGET_MCU=STM32G431 -DBUILD_VARIANT=VTX
cmake --build build-g431-vtx

# STM32G474 + VTX
cmake -B build-g474-vtx -S . -DCMAKE_BUILD_TYPE=Release -DTARGET_MCU=STM32G474 -DBUILD_VARIANT=VTX
cmake --build build-g474-vtx
```


Both variants are now built automatically in CI. GitHub Actions workflow
- Updated matrix to build 4 targets:
- STM32G431 (default)
- STM32G431_VTX
- STM32G474 (default)
- STM32G474_VTX



