### PR TITLE
Splash Screen Timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ venv/
 # Other
 *.swp
 
+.cache
 .idea/
 /build/
 /cmake-build-*/

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@ extern bool new_field;
 
 #define LED_BLINK_INTERVAL 100 // milliseconds
 #define DEBUG_LOOP_INTERVAL 100 // milliseconds
-#define LOGO_TIMEOUT_MS 8000 // 8 seconds
+#define LOGO_TIMEOUT_MS 4000 // 4 seconds
 
 void led_blink(void);
 void logo_timeout_check(void);

--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,10 @@ extern bool new_field;
 
 #define LED_BLINK_INTERVAL 100 // milliseconds
 #define DEBUG_LOOP_INTERVAL 100 // milliseconds
+#define LOGO_TIMEOUT_MS 8000 // 8 seconds
 
 void led_blink(void);
+void logo_timeout_check(void);
 
 void debug_print_loop(void)
 {
@@ -67,6 +69,7 @@ int main (void)
         msp_loop_process();
         led_blink();
         debug_print_loop();
+        logo_timeout_check();
 
 #if 0 // TODO: remove later
 // For test only - 3D cube animation
@@ -87,6 +90,24 @@ void led_blink(void)
     if ((HAL_GetTick() - last_tick) >= LED_BLINK_INTERVAL) {
         LED_STATE_GPIO_Port->ODR ^= LED_STATE_Pin;
         last_tick = HAL_GetTick();
+    }
+}
+
+void logo_timeout_check(void)
+{
+    static uint32_t boot_time = 0;
+    static bool timeout_checked = false;
+    extern bool show_logo;
+    
+    // Initialize boot time on first call
+    if (boot_time == 0) {
+        boot_time = HAL_GetTick();
+    }
+    
+    // Check if 8 seconds have passed and we haven't already timed out
+    if (!timeout_checked && (HAL_GetTick() - boot_time) >= LOGO_TIMEOUT_MS) {
+        show_logo = false;
+        timeout_checked = true;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include "usb.h"
 #include "video_gen.h"
 #include "video_overlay.h"
+
 #if defined(BUILD_VARIANT_VTX)
 #include "rtc6705.h"
 #include <rf_pa.h>
@@ -98,16 +99,18 @@ void logo_timeout_check(void)
     static uint32_t boot_time = 0;
     static bool timeout_checked = false;
     extern bool show_logo;
-    
+
     // Initialize boot time on first call
     if (boot_time == 0) {
         boot_time = HAL_GetTick();
     }
-    
-    // Check if 8 seconds have passed and we haven't already timed out
+
+    // Check if LOGO_TIMEOUT_MS has elapsed, clear logo and version string if so
     if (!timeout_checked && (HAL_GetTick() - boot_time) >= LOGO_TIMEOUT_MS) {
         show_logo = false;
+        // Clear the canvas to remove version string
+        canvas_char_clean();
+        canvas_char_draw_complete();
         timeout_checked = true;
     }
 }
-

--- a/src/main.h
+++ b/src/main.h
@@ -121,4 +121,8 @@ void TIM17_Init(void);
 void COMP3_Init(void);
 void COMP4_Init(void);
 
+/* Canvas character functions */
+EXEC_RAM void canvas_char_clean(void);
+EXEC_RAM void canvas_char_draw_complete(void);
+
 #endif /* __MAIN_H */


### PR DESCRIPTION
Admittedly an opinionated change, but this PR adds a 4 second timeout on boot, after which the logo and version string are cleared from the screen. The intention of this change is to enable unobstructed video where the OSD is installed, but communication via MSP with the FC is non-functional for some reason (e.g. loose connection).