### PR TITLE
Enable LED on boot.

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -18,7 +18,8 @@ void gpio_init(void)
     LL_GPIO_ResetOutputPin(SPI2_CS_GPIO_Port, SPI2_CS_Pin);
 
     /**/
-    LL_GPIO_ResetOutputPin(LED_STATE_GPIO_Port, LED_STATE_Pin);
+    // LED on by default, so that correct flashing and the boot process can be observed.
+    LL_GPIO_SetOutputPin(LED_STATE_GPIO_Port, LED_STATE_Pin);
 
     /**/
     GPIO_InitStruct.Pin = USER_KEY_Pin;


### PR DESCRIPTION
This is helpful during bring-up of new hardware in case the system hangs or hard-faults in the init code.

1) if there's no LED on boot, it's hal/clock configuation error.
2) if there's an LED on boot and it remains lit, it's a hang somewhere after gpi init takes place.
3) if the led begins to flash, then the main loop is running.