### PR TITLE
No external osc support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,27 @@ jobs:
             variant_flag: ""
             job_name: STM32G431
           - mcu: STM32G431
+            variant_flag: "-DBUILD_VARIANT=NO_OSC"
+            job_name: STM32G431_NO_OSC
+          - mcu: STM32G431
             variant_flag: "-DBUILD_VARIANT=VTX"
             job_name: STM32G431_VTX
+          - mcu: STM32G431
+            variant_flag: "-DBUILD_VARIANT=VTX+NO_OSC"
+            job_name: STM32G431_VTX_NO_OSC
 
           - mcu: STM32G474
             variant_flag: ""
             job_name: STM32G474
           - mcu: STM32G474
+            variant_flag: "-DBUILD_VARIANT=NO_OSC"
+            job_name: STM32G474_NO_OSC
+          - mcu: STM32G474
             variant_flag: "-DBUILD_VARIANT=VTX"
             job_name: STM32G474_VTX
+          - mcu: STM32G474
+            variant_flag: "-DBUILD_VARIANT=VTX+NO_OSC"
+            job_name: STM32G474_VTX_NO_OSC
 
     steps:
     - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.22)
 # ===== Build variant selection =====
-#   OpenPixelOSD      -> base OSD (no VTX drivers)
-#   OpenPixelOSD_VTX  -> OSD + VTX (RTC6705 / PA / MSP VTX)
+#   OpenPixelOSD             -> base OSD (no VTX drivers, with external oscillator)
+#   OpenPixelOSD_VTX         -> OSD + VTX (RTC6705 / PA / MSP VTX)
+#   OpenPixelOSD_VTX_NO_OSC  -> OSD + VTX (RTC6705 / PA / MSP VTX, no external oscillator)
 set(BUILD_VARIANT "" CACHE STRING "Build variant: VTX")
 
 set(TARGET_MCU "" CACHE STRING "Target MCU (e.g., STM32G431, STM32G474)")
@@ -117,9 +118,14 @@ else()
     message(FATAL_ERROR "Unsupported MCU type: ${TARGET_MCU}")
 endif()
 
-if(BUILD_VARIANT STREQUAL "VTX")
+#The pattern (^|\\+)${FEATURE_NAME}($|\\+) means:
+#(^|\\+) - Match either start of string (^) OR a plus sign (\\+)
+#${FEATURE_NAME} - Match the feature name exactly
+#($|\\+) - Match either end of string ($) OR a plus sign (\\+)
+
+if(BUILD_VARIANT MATCHES "(^|\\+)VTX($|\\+)")
     message(STATUS "Building with VTX support")
-    set(BUILD_NAME "_VTX")
+    set(BUILD_NAME "${BUILD_NAME}_VTX")
     add_compile_definitions(BUILD_VARIANT_VTX)
     set(VTX_SRC
             ./src/rtc6705.c
@@ -127,10 +133,16 @@ if(BUILD_VARIANT STREQUAL "VTX")
             ./src/vtx_msp.c)
 endif()
 
-if(BUILD_VARIANT STREQUAL "BLINKY")
-    message(STATUS "Building test BLINKY variant")
-    set(BUILD_NAME "_BLINKY")
+if(BUILD_VARIANT MATCHES "(^|\\+)BLINKY($|\\+)")
+    message(STATUS "Building 'blinky' variant")
+    set(BUILD_NAME "${BUILD_NAME}_BLINKY")
     add_compile_definitions(BUILD_VARIANT_BLINKY)
+endif()
+
+if(BUILD_VARIANT MATCHES "(^|\\+)NO_OSC($|\\+)")
+    message(STATUS "Building with no external oscillator support")
+    set(BUILD_NAME "${BUILD_NAME}_NO_OSC")
+    add_compile_definitions(BUILD_VARIANT_NO_OSC)
 endif()
 
 add_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ if(BUILD_VARIANT STREQUAL "VTX")
             ./src/vtx_msp.c)
 endif()
 
+if(BUILD_VARIANT STREQUAL "BLINKY")
+    message(STATUS "Building test BLINKY variant")
+    set(BUILD_NAME "_BLINKY")
+    add_compile_definitions(BUILD_VARIANT_BLINKY)
+endif()
+
 add_compile_definitions(
         USE_FULL_LL_DRIVER
         USE_HAL_DRIVER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Set the project name
-set(CMAKE_PROJECT_NAME OpenPixelOSD LANGUAGES C ASM)
+set(CMAKE_PROJECT_NAME OpenPixelOSD)
 
 # Include toolchain file
 include("cmake/gcc-arm-none-eabi.cmake")
@@ -88,7 +88,7 @@ include("cmake/gcc-arm-none-eabi.cmake")
 # Enable compile command to ease indexing with e.g. clangd
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
-project(${CMAKE_PROJECT_NAME})
+project(${CMAKE_PROJECT_NAME} LANGUAGES C ASM)
 message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
 add_executable(${CMAKE_PROJECT_NAME})
@@ -199,8 +199,7 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 
 # make a zip file containing the hex, bin, map and elf
 set(ZIP_NAME "${CMAKE_PROJECT_NAME}_${TARGET_MCU}_${CMAKE_BUILD_TYPE}${BUILD_NAME}")
-set(TARGET_LANGUAGES "C;ASM")
-set(MAP_FILE "${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME};LANGUAGES;${TARGET_LANGUAGES}.map")
+set(MAP_FILE "${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.map")
 
 # Create ZIP after build completes
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -8,18 +8,31 @@ void gpio_init(void)
 {
     LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
 
-    /* GPIO Ports Clock Enable */
+    /* GPIO Ports Clock Enable (for LED) */
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+
+    // LED on by default, so that correct flashing and the boot process can be observed.
+    LL_GPIO_SetOutputPin(LED_STATE_GPIO_Port, LED_STATE_Pin);
+
+    /**/
+    GPIO_InitStruct.Pin = LED_STATE_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LED_STATE_GPIO_Port, &GPIO_InitStruct);
+
+#if defined(BUILD_VARIANT_BLINKY)
+    return;
+#endif
+
+    /* GPIO Ports Clock Enable */
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOF);
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
 
     /**/
     LL_GPIO_ResetOutputPin(SPI2_CS_GPIO_Port, SPI2_CS_Pin);
-
-    /**/
-    // LED on by default, so that correct flashing and the boot process can be observed.
-    LL_GPIO_SetOutputPin(LED_STATE_GPIO_Port, LED_STATE_Pin);
 
     /**/
     GPIO_InitStruct.Pin = USER_KEY_Pin;
@@ -48,14 +61,6 @@ void gpio_init(void)
     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
     GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
     LL_GPIO_Init(SPI2_SCK_GPIO_Port, &GPIO_InitStruct);
-
-    /**/
-    GPIO_InitStruct.Pin = LED_STATE_Pin;
-    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-    LL_GPIO_Init(LED_STATE_GPIO_Port, &GPIO_InitStruct);
 
     /**/
     GPIO_InitStruct.Pin = BOOT_KEY_Pin;

--- a/src/main.c
+++ b/src/main.c
@@ -37,12 +37,26 @@ void debug_print_loop(void)
     }
 }
 
-
+#if defined(BUILD_VARIANT_BLINKY)
 int main (void)
 {
     HAL_Init();
     SystemClock_Config();
     gpio_init();
+
+    while (1) {
+        led_blink();
+    }
+}
+#endif
+
+#if !defined(BUILD_VARIANT_BLINKY)
+int main (void)
+{
+    HAL_Init();
+    SystemClock_Config();
+    gpio_init();
+
     usb_init();
     dma_init();
     adc_init();
@@ -83,6 +97,7 @@ int main (void)
 
     }
 }
+#endif
 
 void led_blink(void)
 {

--- a/src/stm32g4xx/system.c
+++ b/src/stm32g4xx/system.c
@@ -23,19 +23,27 @@ void SystemClock_Config(void)
     {
     }
     LL_PWR_EnableRange1BoostMode();
-    LL_RCC_HSE_Enable();
-    /* Wait till HSE is ready */
-    while(LL_RCC_HSE_IsReady() != 1)
-    {
-    }
 
+#if defined(BUILD_VARIANT_NO_OSC)
+    LL_RCC_HSI_SetCalibTrimming(64);
     LL_RCC_HSI48_Enable();
     /* Wait till HSI48 is ready */
     while(LL_RCC_HSI48_IsReady() != 1)
     {
     }
+#else
+    LL_RCC_HSE_Enable();
+    /* Wait till HSE is ready */
+    while(LL_RCC_HSE_IsReady() != 1)
+    {
+    }
+#endif
 
+#if defined(BUILD_VARIANT_NO_OSC)
+    LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSI, LL_RCC_PLLM_DIV_4, 85, LL_RCC_PLLR_DIV_2);
+#else
     LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_2, 85, LL_RCC_PLLR_DIV_2);
+#endif
     LL_RCC_PLL_EnableDomain_SYS();
     LL_RCC_PLL_Enable();
     /* Wait till PLL is ready */


### PR DESCRIPTION
Adds support for using the internal HSI.

Currently the system fails to boot when no external resonator is attached on PF0/PF1.

Reference schematic says '*Optional'.

<img width="841" height="596" alt="image" src="https://github.com/user-attachments/assets/66ccb302-bd2a-4d3e-b92b-64900c280330" />

This PR adds two commits.
1) a build variant that makes a 'blinky' (no OSD code, just a blinking LED, this can be used during hardware bring-up to verify that at least the MCU is running.
2) a build variant that allows running with no external oscillator.

I verified this using the MCO output, I will attach pictures to another PR which adds an MCO variant.

Build variants are now ADDITIVE.  Multiple build variants can be given, examples:

```
-D TARGET_MCU=STM32G431 -D BUILD_VARIANT=VTX+NO_OSC
-D TARGET_MCU=STM32G431 -D BUILD_VARIANT=BLINKY+NO_OSC
-D TARGET_MCU=STM32G431 -D BUILD_VARIANT=NO_OSC
-D TARGET_MCU=STM32G431 -D BUILD_VARIANT=BLINKY
```